### PR TITLE
All Python dependencies in binder requirements

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -9,3 +9,5 @@ pyproj
 keras
 tensorflow
 tensorflow_hub
+seaborn
+scikit-learn


### PR DESCRIPTION
Adds the Python dependencies from Lecture 2 & Lecture 6 to the `binder/requirements.txt` file. These will also get installed if the user runs `pip install -r requirements_dev.txt` from the root.

@DanielNwaeze I added `keras`, `tensorflow`, and `tensorflow_hub` to the list based on your notebook (`radiant_mlhub` was already in there). Any others that I should add?