### PR TITLE
Fix dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,16 @@ requirements = Path.cwd().parent.parent / 'binder' / 'requirements.txt'
 !pip install -r $requirements
 ```
 
+There is also an [`environment.yml`](./environment-dev.yml) file that can be used to create a
+`conda` environment.
+
+```
+conda env create -n my-environment -f environment-dev.yml
+```
+
 > **Windows Users**
 > 
 > Some users were experiencing issues when trying to use `rasterio.warp` functions in a Windows
 > environment. This is likely due to [this issue](https://github.com/mapbox/rasterio/issues/2079),
 > which was fixed in version 1.2. If you are experiencing issues with `rasterio.warp` on Windows
 > please verify that you are using `rasterio>=1.2.0`.
- 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ requirements = Path.cwd().parent.parent / 'binder' / 'requirements.txt'
 
 !pip install -r $requirements
 ```
+
+> **Windows Users**
+> 
+> Some users were experiencing issues when trying to use `rasterio.warp` functions in a Windows
+> environment. This is likely due to [this issue](https://github.com/mapbox/rasterio/issues/2079),
+> which was fixed in version 1.2. If you are experiencing issues with `rasterio.warp` on Windows
+> please verify that you are using `rasterio>=1.2.0`.
+ 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -10,8 +10,13 @@ keras==2.4.3
 tensorflow==2.4.1
 tensorflow_hub
 seaborn
-scikit-learn
-pandas
-numpy
-matplotlib
+scikit-learn~=0.24.1
+pandas~=1.1.2
+numpy~=1.19.2
+matplotlib~=3.3.1
 notebook
+scipy~=1.4.1
+scikit-image~=0.16.2
+torch~=1.7.0
+Pillow~=8.10.0
+

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-radiant-mlhub~=0.1.2
+radiant-mlhub~=0.1.3
 rasterio
 fiona
 shapely

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
+  - pytorch
   - defaults
 dependencies:
   - radiant-mlhub >=0.1.3,<1.0.0
@@ -11,7 +12,6 @@ dependencies:
   - boto3
   - pyproj
   - keras==2.4.3
-  - tensorflow==2.4.1
   - tensorflow-hub
   - seaborn
   - scikit-learn
@@ -19,3 +19,10 @@ dependencies:
   - numpy
   - matplotlib
   - jupyter
+  - scipy >=1.4.1,<1.5
+  - scikit-image >=0.16.2,<0.17
+  - pytorch >=1.7.0,<1.8
+  - Pillow >=8.1.0,<8.2
+  - pip
+  - pip:
+    - tensorflow >=2.4.1,<2.5

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,21 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - radiant-mlhub >=0.1.3,<1.0.0
+  - rasterio >=1.2,<2
+  - fiona
+  - shapely
+  - geopandas
+  - arrow
+  - boto3
+  - pyproj
+  - keras==2.4.3
+  - tensorflow==2.4.1
+  - tensorflow-hub
+  - seaborn
+  - scikit-learn
+  - pandas
+  - numpy
+  - matplotlib
+  - jupyter


### PR DESCRIPTION
* Bumps the `radiant_mlhub` version to `>=0.1.3` to fix radiantearth/radiant-mlhub#41
* Adds Lecture 9 dependencies to requirements files
* Adds `environment-dev.yml` file for setting up `conda` environment

*I've tested the `conda` install locally, but it would be good for someone to test it on Windows before merging.*